### PR TITLE
Respect `-Dminecraft.api.session.host`

### DIFF
--- a/src/gg/codie/minecraft/api/SessionServer.java
+++ b/src/gg/codie/minecraft/api/SessionServer.java
@@ -5,7 +5,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 public class SessionServer {
-    private static final String BASE_URL = "https://sessionserver.mojang.com";
+    private static final String BASE_URL = System.getProperty("minecraft.api.session.host", "https://sessionserver.mojang.com");
 
     public static boolean hasJoined(String username, String serverId, String ip) throws IOException {
         HttpURLConnection connection;


### PR DESCRIPTION
Since 1.16, Vanilla Minecraft has built-in support for overriding the API server URLs via these system properties:

```
minecraft.api.auth.host
minecraft.api.account.host
minecraft.api.session.host
minecraft.api.services.host
```

If the system properties are not defined, the game falls back to the default Mojang values (`https://authserver.mojang.com`, `https://api.mojang.com`, etc.).

With this patch, OnlineModeFix respects `minecraft.api.session.host` so users can supply their own session server URL if they want to use a different authentication server. Example launch command:

```
java -Dminecraft.api.session.host=https://drasl.unmojang.org \
    -Djava.protocol.handler.pkgs=gg.codie.mineonline.protocol \
    -cp minecraft_server.jar:OnlineModeFix.jar \
    net.minecraft.server.MinecraftServer
```